### PR TITLE
matplotlib 3.7.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # Full credit goes to https://github.com/conda/conda-recipes for providing this recipe.
 # It has been subsequently adapted for automated building with conda-forge.
 
-{% set version = "3.6.2" %}
+{% set version = "3.7.0" %}
 
 package:
   name: matplotlib-suite
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/matplotlib/matplotlib/archive/v{{ version }}.tar.gz
-  sha256: 5ac5ca25e6ecd1e7711e1f859b4b6f74f290ef517387d1502bf8012bf2b1647e
+  sha256: e3a799e17fbee6949b4c3ca99d8bb05d847f39212a6f25e141de7389c96c99ca
   patches:
     # s390x fails to download qhull. This patch changes the download URL to point to Github. 
     # You must manually update LOCAL_QHULL_VERSION and LOCAL_QHULL_HASH from upstream.


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index eed84fb..db0c8bd 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # Full credit goes to https://github.com/conda/conda-recipes for providing this recipe.
 # It has been subsequently adapted for automated building with conda-forge.
 
-{% set version = "3.6.2" %}
+{% set version = "3.7.0" %}
 
 package:
   name: matplotlib-suite
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/matplotlib/matplotlib/archive/v{{ version }}.tar.gz
-  sha256: 5ac5ca25e6ecd1e7711e1f859b4b6f74f290ef517387d1502bf8012bf2b1647e
+  sha256: e3a799e17fbee6949b4c3ca99d8bb05d847f39212a6f25e141de7389c96c99ca
   patches:
     # s390x fails to download qhull. This patch changes the download URL to point to Github. 
     # You must manually update LOCAL_QHULL_VERSION and LOCAL_QHULL_HASH from upstream.

```

**Jira ticket:** [PKG-997
PKG-989
PKG-736
PKG-151](https://anaconda.atlassian.net/browse/PKG-997
https://anaconda.atlassian.net/browse/PKG-989
https://anaconda.atlassian.net/browse/PKG-736
https://anaconda.atlassian.net/browse/PKG-151) (
matplotlib
matplotlib
matplotlib-
3.6.3
3.6.2
3.5.3)

**The upstream data:**
Github releases:  https://github.com/matplotlib/matplotlib//releases
[Diff between the latest and previous upstream releases](https://github.com/matplotlib/matplotlib//compare/3.6.2...3.7.0)
Requirements:
 * setup.cfg:  https://github.com/matplotlib/matplotlib//blob/v3.7.0/setup.cfg
 * setup.py:  https://github.com/matplotlib/matplotlib//blob/v3.7.0/setup.py
 *  pyproject.toml:  https://github.com/matplotlib/matplotlib//blob/v3.7.0/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: easy | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 3.7.0
 * Release on PyPi:
    * version: 3.7.0
    * date: 2023-02-13T22:53:48
* [PyPi history](https://pypi.org/project/matplotlib/#history)
 * Popularity: 
    * 3 months downloads: 2098304.0
Key is not found. 0

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
3. - [x] has `setuptools`
5. - [x] has `wheel`
7. - [x] `pip` in test
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE/LICENSE is present

14. - [x] license_family PSF is present
16. - [x] License: LicenseRef-PSF-based
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier   |
|--------------|
</details>

**Check dependency issues:**

<details>
../aggregate/matplotlib-feedstock/recipe/meta.yaml
Dependencies: ['setuptools_scm_git_archive', 'tornado >=5', 'pillow >=6.2.0', 'certifi >=2020.06.20', 'python-dateutil >=2.7', 'packaging >=20.0', 'fonttools >=4.22.0', 'setuptools_scm >=7', 'pyparsing >=2.2.1', 'numpy', 'python', 'freetype', 'matplotlib-base', 'wheel', 'pip >=9.0.1', 'zlib', 'freetype >=2.3', 'setuptools', 'contourpy >=1.0.1', 'cycler >=0.10', 'kiwisolver >=1.0.1']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.8:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.9:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0

- py3.10:  Encountered problems while solving:
  - nothing provides __glibc >=2.17 needed by libstdcxx-ng-11.2.0-h1234567_0


linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: expected token 'end of print statement', got 'float'
None**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/matplotlib-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/matplotlib-feedstock/tree/3.7.0)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/matplotlib)
* [Diff between upstream and feature branch](https://github.com/conda-forge/matplotlib-feedstock/compare/main...AnacondaRecipes:3.7.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/matplotlib-feedstock/compare/master...AnacondaRecipes:3.7.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/matplotlib-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 3.7.0 git@github.com:AnacondaRecipes/matplotlib-feedstock.git
```
