### PR TITLE
update version to 3.8.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - patch  # [unix]
+        - libgcc-devel_linux-s390x # [s390x] 
       host:
         - python
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,13 +14,15 @@ source:
 
 build:
   number: 0
-  
+
 outputs:
   - name: matplotlib-base
     script: build_base.bat  # [win]
     script: build_base.sh  # [not win]
     build:
       skip: true  # [py<39]
+      missing_dso_whitelist:  # [s390x]
+        - $RPATH/ld64.so.1    # [s390x]
     requirements:
       build:
         - pkg-config 
@@ -73,6 +75,8 @@ outputs:
   - name: matplotlib
     build:
       skip: true  # [py<39]
+      missing_dso_whitelist:  # [s390x]
+        - $RPATH/ld64.so.1    # [s390x]
     requirements:
       host:
         - python
@@ -92,6 +96,8 @@ outputs:
       # running into some odd install issues with noarch on win32 only.
       skip: true  # [win32 or python_impl == "pypy"]
       skip: true  # [py<39]
+      missing_dso_whitelist:  # [s390x]
+        - $RPATH/ld64.so.1    # [s390x]
       noarch: python
     requirements:
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # Full credit goes to https://github.com/conda/conda-recipes for providing this recipe.
 # It has been subsequently adapted for automated building with conda-forge.
 
-{% set version = "3.8.0" %}
+{% set version = "3.8.4" %}
 
 package:
   name: matplotlib-suite
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/matplotlib/matplotlib/archive/v{{ version }}.tar.gz
-  sha256: 83e97200421dc8b0022eba92f03174d9bf80c966df25a6f03f44608bfe36a7ac
+  sha256: 7c4f370b7550eec8342c102f9dd80da3bec2895d7f514f5f6378764db4cb0e35
   patches:  # [unix]
     # s390x fails to download qhull. This patch changes the download URL to point to Github. 
     # You must manually update LOCAL_QHULL_VERSION and LOCAL_QHULL_HASH from upstream.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,15 +7,6 @@ package:
 source:
   url: https://github.com/matplotlib/matplotlib/archive/v{{ version }}.tar.gz
   sha256: 7c4f370b7550eec8342c102f9dd80da3bec2895d7f514f5f6378764db4cb0e35
-  patches:  # [unix]
-    # s390x fails to download qhull. This patch changes the download URL to point to Github. 
-    # You must manually update LOCAL_QHULL_VERSION and LOCAL_QHULL_HASH from upstream.
-    - 000_use_github_url_qhull.patch  # [unix]
-
-build:
-  number: 0
-  ignore_run_exports:
-    - libgcc-ng
 
 outputs:
   - name: matplotlib-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,6 @@ source:
 
 build:
   number: 0
-  missing_dso_whitelist:
-    - /opt/conda/conda-bld/matplotlib-suite_*_s390x-conda-linux-gnu/sysroot/lib64/ld64.so.1
 
 outputs:
   - name: matplotlib-base
@@ -38,7 +36,7 @@ outputs:
         - certifi >=2020.06.20
         - freetype 2.10
         - numpy {{ numpy }}
-        - setuptools 
+        - setuptools >=64
         - setuptools_scm >=7
         - wheel
         - pybind11 >=2.6
@@ -49,10 +47,10 @@ outputs:
         - contourpy >=1.0.1
         - fonttools >=4.22.0
         - freetype >=2.10
-        - kiwisolver >=1.0.1
+        - kiwisolver >=1.3.1
         - {{ pin_compatible('numpy') }}
         - packaging >=20.0
-        - pillow >=6.2.0
+        - pillow >=8
         - pyparsing >=2.3.1,<3.1
         - python-dateutil >=2.7
         - importlib_resources >=3.2.0  # [py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,9 @@ source:
   url: https://github.com/matplotlib/matplotlib/archive/v{{ version }}.tar.gz
   sha256: 7c4f370b7550eec8342c102f9dd80da3bec2895d7f514f5f6378764db4cb0e35
 
+build:
+  number: 0
+  
 outputs:
   - name: matplotlib-base
     script: build_base.bat  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,8 @@ source:
 
 build:
   number: 0
+  missing_dso_whitelist:
+    - /opt/conda/conda-bld/matplotlib-suite_*_s390x-conda-linux-gnu/sysroot/lib64/ld64.so.1
 
 outputs:
   - name: matplotlib-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,3 @@
-# Full credit goes to https://github.com/conda/conda-recipes for providing this recipe.
-# It has been subsequently adapted for automated building with conda-forge.
-
 {% set version = "3.8.4" %}
 
 package:
@@ -17,6 +14,8 @@ source:
 
 build:
   number: 0
+  ignore_run_exports:
+    - libgcc-ng
 
 outputs:
   - name: matplotlib-base
@@ -30,14 +29,13 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - patch  # [unix]
-        - libgcc-devel_linux-s390x # [s390x] 
       host:
         - python
         - pip
         - certifi >=2020.06.20
         - freetype 2.10
         - numpy {{ numpy }}
-        - setuptools >=64
+        - setuptools 
         - setuptools_scm >=7
         - wheel
         - pybind11 >=2.6
@@ -48,10 +46,10 @@ outputs:
         - contourpy >=1.0.1
         - fonttools >=4.22.0
         - freetype >=2.10
-        - kiwisolver >=1.3.1
+        - kiwisolver >=1.0.1
         - {{ pin_compatible('numpy') }}
         - packaging >=20.0
-        - pillow >=8
+        - pillow >=6.2.0
         - pyparsing >=2.3.1,<3.1
         - python-dateutil >=2.7
         - importlib_resources >=3.2.0  # [py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,8 +75,6 @@ outputs:
   - name: matplotlib
     build:
       skip: true  # [py<39]
-      missing_dso_whitelist:  # [s390x]
-        - $RPATH/ld64.so.1    # [s390x]
     requirements:
       host:
         - python
@@ -96,8 +94,6 @@ outputs:
       # running into some odd install issues with noarch on win32 only.
       skip: true  # [win32 or python_impl == "pypy"]
       skip: true  # [py<39]
-      missing_dso_whitelist:  # [s390x]
-        - $RPATH/ld64.so.1    # [s390x]
       noarch: python
     requirements:
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,3 +1,6 @@
+# Full credit goes to https://github.com/conda/conda-recipes for providing this recipe.
+# It has been subsequently adapted for automated building with conda-forge.
+
 {% set version = "3.8.4" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,10 +49,10 @@ outputs:
         - contourpy >=1.0.1
         - fonttools >=4.22.0
         - freetype >=2.10
-        - kiwisolver >=1.0.1
+        - kiwisolver >=1.3.1
         - {{ pin_compatible('numpy') }}
         - packaging >=20.0
-        - pillow >=6.2.0
+        - pillow >=8
         - pyparsing >=2.3.1,<3.1
         - python-dateutil >=2.7
         - importlib_resources >=3.2.0  # [py<310]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,10 @@ package:
 source:
   url: https://github.com/matplotlib/matplotlib/archive/v{{ version }}.tar.gz
   sha256: 7c4f370b7550eec8342c102f9dd80da3bec2895d7f514f5f6378764db4cb0e35
+  patches:  # [unix]
+    # s390x fails to download qhull. This patch changes the download URL to point to Github. 
+    # You must manually update LOCAL_QHULL_VERSION and LOCAL_QHULL_HASH from upstream.
+    - 000_use_github_url_qhull.patch  # [unix]
 
 build:
   number: 0


### PR DESCRIPTION
matplotlib 3.8.4 

**Destination channel:** defaults

### Links

- [PKG-4402](https://anaconda.atlassian.net/browse/PKG-4402) 
- [Upstream repository](https://github.com/matplotlib/matplotlib)
- [Upstream changelog/diff](https://github.com/matplotlib/matplotlib/releases/tag/v3.8.4)

### Explanation of changes:
- update version and sha


[PKG-4402]: https://anaconda.atlassian.net/browse/PKG-4402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ