### PR TITLE
matplotlib 3.10.8 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # Full credit goes to https://github.com/conda/conda-recipes for providing this recipe.
 # It has been subsequently adapted for automated building with conda-forge.
 {% set name = "matplotlib" %}
-{% set version = "3.10.7" %}
+{% set version = "3.10.8" %}
 
 package:
   name: {{ name }}-suite
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 0678f04e55c839c543a3803a7a13ab427f488ff396d85ffbad7d427f6fdcbbc3
+  sha256: dbc50c7b15bb8d7dbe51a27a58322ed73f09291772d9e3184f03f11c576693f7
 
 build:
   number: 0


### PR DESCRIPTION
matplotlib 3.10.8 

**Destination channel:** Defaults

### Links

- [PKG-11872]
- dev_url:        https://github.com/matplotlib/matplotlib/tree/v3.10.8
- conda_forge:    https://github.com/conda-forge/matplotlib-feedstock
- pypi:           https://pypi.org/project/matplotlib/3.10.8
- pypi inspector: https://inspector.pypi.io/project/matplotlib/3.10.8

### Explanation of changes:

- new version number


[PKG-11872]: https://anaconda.atlassian.net/browse/PKG-11872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ