### PR TITLE
matplotlib 3.10.9 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # Full credit goes to https://github.com/conda/conda-recipes for providing this recipe.
 # It has been subsequently adapted for automated building with conda-forge.
 {% set name = "matplotlib" %}
-{% set version = "3.10.8" %}
+{% set version = "3.10.9" %}
 
 package:
   name: {{ name }}-suite
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: dbc50c7b15bb8d7dbe51a27a58322ed73f09291772d9e3184f03f11c576693f7
+  sha256: 55251fcbca725a3b7ed20aefaff07a67560ffb0a7d739ebab0c99eb14f4c2d94
 
 build:
   number: 0
@@ -30,9 +30,10 @@ outputs:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
         - pkg-config
+        - ninja-base
       host:
-        - python
         - pip
+        - python
         - freetype {{ freetype }}
         - numpy {{ numpy }}
         - setuptools_scm >=7


### PR DESCRIPTION
matplotlib 3.10.9 

**Destination channel:** Defaults

### Links

- [PKG-13841]
- dev_url:        https://github.com/matplotlib/matplotlib/tree/v3.10.9
- conda_forge:    https://github.com/conda-forge/matplotlib-feedstock
- pypi:           https://pypi.org/project/matplotlib/3.10.9
- pypi inspector: https://inspector.pypi.io/project/matplotlib/3.10.9

### Explanation of changes:

- new version number


[PKG-13841]: https://anaconda.atlassian.net/browse/PKG-13841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ